### PR TITLE
allow one month duration cookies

### DIFF
--- a/lib/session_management/application_controller.rb
+++ b/lib/session_management/application_controller.rb
@@ -8,6 +8,8 @@ module SessionManagement::ApplicationController
       cookies.permanent[:auth_token] = user.auth_token
     elsif opts[:provider]
       cookies[:auth_token] = { value: user.auth_token, expires: 1.week.from_now }
+    elsif opts[:one_month]
+      cookies[:auth_token] = { value: user.auth_token, expires: 1.month.from_now }
     else
       cookies[:auth_token] = user.auth_token
     end


### PR DESCRIPTION
this is what we actually need at the moment.

alternately, an option could be added that would allow an arbitrary time period for expiry.